### PR TITLE
Create Intro.md

### DIFF
--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -1,0 +1,60 @@
+# OpenAI Agents SDK
+
+The [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) enables you to build agentic AI apps in a lightweight, easy-to-use package with very few abstractions. It's a production-ready upgrade of our previous experimentation for agents, [Swarm](https://github.com/openai/swarm/tree/main). The Agents SDK has a very small set of primitives:
+
+* Agents, which are LLMs equipped with instructions and tools
+* Handoffs, which allow agents to delegate to other agents for specific tasks
+* Guardrails, which enable validation of agent inputs and outputs
+* Sessions, which automatically maintains conversation history across agent runs
+  
+In combination with Python, these primitives are powerful enough to express complex relationships between tools and agents, and allow you to build real-world applications without a steep learning curve. In addition, the SDK comes with built-in tracing that lets you visualize and debug your agentic flows, as well as evaluate them and even fine-tune models for your application.
+
+
+## Why use the Agents SDK
+
+The main reason for using the OpenAI Agent SDK is:
+
+It simplifies the process of building autonomous, multi-step agents that can use tools, call APIs, maintain context, and make decisions — without you having to manually code all the orchestration logic.
+
+Here are the main features of the SDK:
+
+* Agent loop: Built-in agent loop that handles calling tools, sending results to the LLM, and looping until the LLM is done.
+
+* Python-first: Use built-in language features to orchestrate and chain agents, rather than needing to learn new abstractions.
+
+* Handoffs: A powerful feature to coordinate and delegate between multiple agents.
+
+* Guardrails: Run input validations and checks in parallel to your agents, breaking early if the checks fail.
+
+* Sessions: Automatic conversation history management across agent runs, eliminating manual state handling.
+
+* Function tools: Turn any Python function into a tool, with automatic schema generation and Pydantic-powered validation.
+
+* Tracing: Built-in tracing that lets you visualize, debug and monitor your workflows, as well as use the OpenAI suite of evaluation, fine-tuning and distillation tools. 
+
+
+## Installation
+
+```python
+pip install openai-agents
+```
+
+
+## Hello world example
+
+```python
+from agents import Agent, Runner
+
+agent = Agent(name="Assistant", instructions="You are a helpful assistant")
+
+result = Runner.run_sync(agent, "Write a haiku about recursion in programming.")
+print(result.final_output)
+
+# Code within the code,
+# Functions calling themselves,
+# Infinite loop's dance.
+```
+(If running this, ensure you set the OPENAI_API_KEY environment variable)
+```python
+export OPENAI_API_KEY=sk-...
+```


### PR DESCRIPTION
The main reason for using the OpenAI Agent SDK is:

It simplifies the process of building autonomous, multi-step agents that can use tools, call APIs, maintain context, and make decisions — without you having to manually code all the orchestration logic.

